### PR TITLE
Remove unnecessary manifest link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -18,8 +18,6 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <!-- webpackIgnore: true -->
-  <link rel="manifest" href="manifest.webmanifest">
 </head>
 <body>
   <p>Smart Card API Demo</p>


### PR DESCRIPTION
It is unnecessary, invalid and confusing - as the app in developer mode prompts for installing it as PWA (which it's not) if it's valid.